### PR TITLE
Update to feature extraction procedure for normal feature creation

### DIFF
--- a/code/preproc/featextract.q
+++ b/code/preproc/featextract.q
@@ -37,8 +37,7 @@ prep.normalcreate:{[t;p]
   // but are not transformed according to remaining procedures
   tcols:.ml.i.fndcols[t;"dmntvupz"];
   tb:(cols[t]except tcols)#t;
-  tb:prep.i.truncsvd[tb;::;2];
-  tb:prep.i.bulktransform[tb;::];
+  tb:prep.i.applyfn/[tb;p`funcs];
   tb:.ml.dropconstant prep.i.nullencode[.ml.infreplace tb;med];
   // Apply the transform of time specific columns as appropriate
   if[0<count tcols;tb^:.ml.timesplit[tcols#t;::]];

--- a/code/preproc/utils.q
+++ b/code/preproc/utils.q
@@ -120,20 +120,31 @@ prep.i.credibility:{[t;c;tgt]
 
 // Perform bulk transformations of hij columns for all unique linear combinations of such columns
 /. r > table with bulk transformtions applied appropriately
-prep.i.bulktransform:{[t;c]
-  if[(::)~c;c:.ml.i.fndcols[t;"hij"]];
+prep.i.bulktransform:{[t]
+  c:.ml.i.fndcols[t;"hij"];
   // Name the columns based on the unique combinations
   n:raze(,'/)`$(raze each string c@:.ml.combs[count c;2]),\:/:("_multi";"_sum";"_div";"_sub");
   // Apply transforms based on naming conventions chosen and re-form the table with these appended
   flip flip[t],n!(,/)(prd;sum;{first(%)x};{last deltas x})@/:\:t c}
 
+// Used for the recursive application of functions to a kdb+ table
+/* fn = function to be applied to the table
+/* t  = table
+/. table with the desired transform applied
+prep.i.applyfn:{[t;fn]@[;t]$[-11h=type fn;get[fn];fn]}
+
 // Perform a truncated single value decomposition on unique linear combinations of float columns
 // https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html
-prep.i.truncsvd:{[t;c;p]
-  if[(::)~c;c:.ml.i.fndcols[t;"f"]];
-  c@:.ml.combs[count c,:();p];
+prep.i.truncsvd:{[t]
+  c:.ml.i.fndcols[t;"f"];
+  c@:.ml.combs[count c,:();2];
   svd:.p.import[`sklearn.decomposition;`:TruncatedSVD;`n_components pykw 1];
   flip flip[t],(`$(raze each string c),\:"_trsvd")!{raze x[`:fit_transform][flip y]`}[svd]each t c}
+
+// Default behaviour for the system is to pass through the table without the application of
+// any feature extraction procedures, this is for computational efficiency in initial builds
+// of the system and may be augmented with a more intelligent system moving forward
+prep.i.default:{[t]t}
 
 // Error message related to the 'refusal' of the feature significance tests to 
 // find appropriate columns to explain the data from those produced

--- a/code/utils.q
+++ b/code/utils.q
@@ -53,8 +53,10 @@ i.getdict:{[nm]
     $[`scf in k;`scf;()];
     $[`seed in k:key d;`seed;()]);
   fnc:(key;
-       {get string first x};{(x 0;get string x 1)};
-       {key[x]!`$value x};{$[`rand_val~first x;first x;get string first x]});
+    {get string first x};
+    {(x 0;get string x 1)};
+    {key[x]!`$value x};
+    {$[`rand_val~first x;first x;get string first x]});
   // Addition of empty dictionary entry needed as parsing 
   // of file behaves oddly if only a single entry is given to the system
   if[sgl:1=count d;d:(enlist[`]!enlist""),d];
@@ -69,9 +71,9 @@ i.getdict:{[nm]
 i.freshdefault:{`aggcols`params`xv`gs`prf`scf`seed`saveopt`hld`tts`sz!
   ({first cols x};`.ml.fresh.params;(`.ml.xv.kfshuff;5);(`.ml.gs.kfshuff;5);`.aml.xv.fitpredict;
    `class`reg!(`.ml.accuracy;`.ml.mse);`rand_val;2;0.2;`.ml.ttsnonshuff;0.2)}
-i.normaldefault:{`xv`gs`prf`scf`seed`saveopt`hld`tts`sz!
-  ((`.ml.xv.kfshuff;5);(`.ml.gs.kfshuff;5);`.aml.xv.fitpredict;`class`reg!(`.ml.accuracy;`.ml.mse);
-   `rand_val;2;0.2;`.ml.traintestsplit;0.2)}
+i.normaldefault:{`xv`gs`funcs`prf`scf`seed`saveopt`hld`tts`sz!
+  ((`.ml.xv.kfshuff;5);(`.ml.gs.kfshuff;5);`.aml.prep.i.default;`.aml.xv.fitpredict;
+   `class`reg!(`.ml.accuracy;`.ml.mse);`rand_val;2;0.2;`.ml.traintestsplit;0.2)}
 
 // Apply an appropriate scoring function to predictions from a model
 /* xtst = test data
@@ -182,7 +184,7 @@ i.normalproc:{[t;p]
   t:prep.i.symencode[t;10;0;p;p`symencode];
   t:prep.i.nullencode[t;med];
   t:.ml.infreplace[t];
-  t:first prep.normalcreate[t;::];
+  t:first prep.normalcreate[t;p];
   flip value flip p[`features]#t}
 
 // Apply feature creation and encoding procedures for FRESH on new data


### PR DESCRIPTION
* Feature creation in non-fresh case now defaults to **not** apply feature creation by default
    - naive application of truncated svd and bulk transform have can cause issues in  
* Modification of the fiels `funcs` in the default dictionary to add function names (as symbols in dict case) allows a user to apply any transform they desire to the data provided the function takes in a table and returns a table
* bulktransform and truncated svd functions now default to take only one parameter with applications on all relevant columns and combinations of degree 2