### PR TITLE
PyTorch Model support Addition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
   - if [ $TRAVIS_OS_NAME = linux ]; then QLIBDIR=l64; elif [ $TRAVIS_OS_NAME = osx ]; then QLIBDIR=m64; else echo "unknown OS ('$TRAVIS_OS_NAME')" >&2; exit 1; fi; export QLIBDIR
   - conda install -c kx embedPy # grab kdb+ and embedPy with conda
-  - cp -r $(conda info --root)/q q && export QHOME=$(pwd)/q && export PATH=$QHOME/$QLIBDIR:$PATH
+  - cp -r $(conda info --base)/q q && export QHOME=$(pwd)/q && export PATH=$QHOME/$QLIBDIR:$PATH
   # grab latest embedpy
   - if [[ "x$QLIC_KC" != "x" ]]; then
       echo -n $QLIC_KC |base64 --decode > q/kc.lic;

--- a/code/aml.q
+++ b/code/aml.q
@@ -65,6 +65,7 @@ run:{[tb;tgt;ftype;ptype;p]
   -1 i.runout[`sco],string[score],"\n";
   // Print confusion matrix for classification problems
   if[ptype~`class;
+    if[not type[pred]~type[tts`ytest];pred:`long$pred;tts[`ytest]:`long$tts[`ytest]];
     -1 i.runout[`cnf];show .ml.conftab[pred;tts`ytest];
     if[dict[`saveopt]in 1 2;post.i.displayCM[value .ml.confmat[pred;tts`ytest];`$string asc distinct pred,tts`ytest;"";();bm 1;spaths]]];
   // Save down a pdf report summarizing the running of the pipeline
@@ -76,9 +77,10 @@ run:{[tb;tgt;ftype;ptype;p]
   if[dict[`saveopt]in 1 2;
     // Extract the Python library from which the best model was derived, used for model rerun
     pylib:?[mdls;enlist(=;`model;enlist bm 1);();`lib];
+    mtyp:?[mdls;enlist(=;`model;enlist bm 1);();`typ];
     // additional metadata information to be saved to disk
     hp:$[b;enlist[`hyper_parameters]!enlist prms 1;()!()];
-    exmeta:`features`test_score`best_model`symencode`pylib!(feats;score;bm 1;encoding;pylib 0);
+    exmeta:`features`test_score`best_model`symencode`pylib`mtyp!(feats;score;bm 1;encoding;pylib 0;mtyp 0);
     metadict:dict,hp,exmeta;
     i.savemdl[bm 1;expmdl;mdls;spaths];
     i.savemeta[metadict;dtdict;spaths]];
@@ -120,7 +122,7 @@ new:{[t;dt;tm]
       if[trch:mdl in i.torchlist;model[`:eval][]];
       // If PyTorch/Keras model then use the defined prediction function
       $[bool|trch;
-        [fnm:neg[5]_string lower mdl;
+        [fnm:string metadata`mtyp;
          get[".automl.",fnm,"predict"][(0n;(data;0n));model]];
         model[`:predict;<]data]];
     '`$"The current model type you are attempting to apply is not currently supported"]

--- a/code/models/lib_support/keras.p
+++ b/code/models/lib_support/keras.p
@@ -1,0 +1,3 @@
+# This file can be populated by a user with Python code to be used in the application of Keras models
+# by default this script is empty as the Keras models to be applied are at present all defined
+# using embedPy syntax

--- a/code/models/lib_support/keras.q
+++ b/code/models/lib_support/keras.q
@@ -26,7 +26,7 @@ binaryfit:regfit:multifit:{[d;m]m[`:fit][npa d[0]0;d[0]1;`batch_size pykw 32;`ve
 /. r > the compiled keras models
 binarymdl:{[d;s;mtype]
   nps[s];
-  if[not 1~checkimport[];tfs[s]];
+  if[0~checkimport[0];tfs[s]];
   m:seq[];
   m[`:add]dns[32;`activation pykw"relu";`input_dim pykw count first d[0]0];
   m[`:add]dns[1;`activation pykw "sigmoid"];
@@ -35,7 +35,7 @@ binarypredict:{[d;m].5<raze m[`:predict][npa d[1]0]`}
 
 regmdl:{[d;s;mtype]
   nps[s];
-  if[not 1~checkimport[];tfs[s]];
+  if[0~checkimport[0];tfs[s]];
   m:seq[];
   m[`:add]dns[32;`activation pykw "relu";`input_dim pykw count first d[0]0];
   m[`:add]dns[1 ;`activation pykw "relu"];
@@ -44,7 +44,7 @@ regpredict   :{[d;m]raze m[`:predict][npa d[1]0]`}
 
 multimdl:{[d;s;mtype]
   nps[s];
-  if[not 1~checkimport[];tfs[s]];
+  if[0~checkimport[0];tfs[s]];
   m:seq[];
   m[`:add]dns[32;`activation pykw "relu";`input_dim pykw count first d[0]0];
   m[`:add]dns[count distinct (d[0]1)`;`activation pykw "softmax"];
@@ -55,7 +55,9 @@ npa:.p.import[`numpy]`:array;
 seq:.p.import[`keras.models]`:Sequential;
 dns:.p.import[`keras.layers]`:Dense;
 nps:.p.import[`numpy.random][`:seed];
-if[not 1~checkimport[];tf:.p.import[`tensorflow];tfs:tf$[2>"I"$first tf[`:__version__]`;[`:set_random_seed];[`:random.set_seed]]];
+if[0~checkimport[0];
+  tf:.p.import[`tensorflow];
+  tfs:tf$[2>"I"$first tf[`:__version__]`;[`:set_random_seed];[`:random.set_seed]]];
 
 / allow multiprocess
 .ml.loadfile`:util/mproc.q

--- a/code/models/lib_support/torch.p
+++ b/code/models/lib_support/torch.p
@@ -1,0 +1,3 @@
+# This file can be populated with required Python code for the addition of PyTorch models
+# no models are defined here by default as suitable PyTorch models for addition to the pipeline
+# may be added down the line

--- a/code/models/lib_support/torch.q
+++ b/code/models/lib_support/torch.q
@@ -1,0 +1,13 @@
+// The purpose of this file is to include all the necessary utilities to create a minimal
+// interface for the support of PyTorch models. It also acts as a location to which users defined
+// PyTorch models could be added
+
+\d .automl
+
+// import pytorch as torch
+torch:.p.import[`torch];
+
+// list all defined PyTorch models defined by the user, here `null as none are to be used by default
+i.torchlist:`null;
+i.nnlist:i.keraslist,i.torchlist
+

--- a/code/postproc/utils.q
+++ b/code/postproc/utils.q
@@ -36,7 +36,7 @@ post.i.predshuff:{[bs;mdl;data;scf;cr;p]
   epymdl:mdl[0];mdltb:mdl[1];
   xtest:post.i.shuffle[data 2;cr];
   funcnm:string first exec fnc from mdltb where model=bs;
-  preds:$[bs in i.keraslist;
+  preds:$[bs in i.nnlist;
         get[".automl.",funcnm,"predict"][((data 0;data 1);(xtest;data 3));epymdl];
         epymdl[`:predict][xtest]`];
   scf[;data 3]preds

--- a/code/preproc/checkimport.p
+++ b/code/preproc/checkimport.p
@@ -1,9 +1,15 @@
 # Ensure that a user that is attempting to use the framework
 # has the required dependencies for neural network models
-p)def< checkimport():
-  try:
-    import tensorflow
-    import keras
+p)def< checkimport(x):
+  if(x==0):
+    try:
+      import tensorflow;import keras;return(0)
+    except:
+      return(1)
+  elif(x==1):
+    try:
+      import torch;return(0)
+    except:
+      return(1)
+  else:
     return(0)
-  except:
-    return(1)

--- a/code/proc/proc.q
+++ b/code/proc/proc.q
@@ -32,7 +32,7 @@ proc.runmodels:{[data;tgt;mdls;cnms;p;dt;fpath]
   // Extract the best model, fit on entire training set and predict/score on test set
   // for the appropriate scoring function
   bm_tstart:.z.T;
-  $[bs in i.keraslist;
+  $[bs in i.nnlist;
     [data:((xtrn;ytrn);(xtst;ytst));
      funcnm:string first exec fnc from mdls where model=bs;
      if[funcnm~"multi";data[;1]:npa@'reverse flip@'./:[;((::;0);(::;1))](0,count ytst)_/:

--- a/code/proc/utils.q
+++ b/code/proc/utils.q
@@ -15,7 +15,7 @@ proc.i.files:`class`reg`score!("classmodels.txt";"regmodels.txt";"scoring.txt")
 /* fnc = function name if keras or module from which model is derived for keras
 /. r   > the appropriate function or projection in the case of sklearn
 proc.i.mdlfunc:{[lib;fnc;mdl]
-  $[`keras~lib;
+  $[lib in `keras`pytorch;
     // retrieve keras model from the .automl namespace eg '.automl.regfitscore'
     get` sv``automl,`fitscore;
     // construct the projection used for sklearn models eg '.p.import[`sklearn.svm][`:SVC]'

--- a/init.q
+++ b/init.q
@@ -14,9 +14,14 @@ loadfile`:code/preproc/featextract.q
 loadfile`:code/proc/utils.q
 loadfile`:code/proc/proc.q
 loadfile`:code/proc/xvgs.q
-$[0~checkimport[];
-  loadfile`:code/models/kerasmdls.q;
+$[0~checkimport[0];
+  [loadfile`:code/models/lib_support/keras.q;
+   loadfile`:code/models/lib_support/keras.p];
   [-1"Requirements for deep learning models not available, these will not be run";]]
+$[0~checkimport[1];
+  [loadfile`:code/models/lib_support/torch.q;
+   loadfile`:code/models/lib_support/torch.p];
+  [-1"Requirements for deep PyTorch models not satisfied, these will not be supported.";]]
 loadfile`:code/postproc/plots.q
 loadfile`:code/postproc/report.q
 loadfile`:code/postproc/utils.q

--- a/tests/postproc.t
+++ b/tests/postproc.t
@@ -16,5 +16,3 @@ mdl:clf[`:fit][data 0;data 1]
 post.i.impact[0.1 0.5 0.2 0.6 0;`x`x1`x2`x3`x4;desc]~`x3`x1`x2`x`x4!0.4 0.5 0.8 0.9 1f
 post.i.impact[0.5 0.4 0.2 0.8 0.7;`x`x1`x2`x3`x4;asc]~`x2`x1`x`x4`x3!0.25 0.5 0.625 0.875 1
 
-// Gain and percentile for gain curve
-post.cgcurve[data 3;mdl[`:predict_proba][data 2]`]~([]pc:01b;gain:flip(0 0f;0 1%3;0 1%3;0.5,1%3;0.5,2%3;1 1f);pcnt:(0 0.2 0.4 0.6 0.8 1;0 0.2 0.4 0.6 0.8 1))


### PR DESCRIPTION
* Minimal required changes necessary for the addition of PyTorch model support
    * Defined PyTorch models should be of the form `classtorch`/`regtorch` i.e. models are defined with a following `torch`
    * User is not required to have PyTorch installed but can still run entire pipelines including models with Keras. Overhaul of checkimport allows this to happen 
* Movement of Neural network models keras/pytorch to `code/models/lib_support`
* Addition of python scripts in `code/models/lib_support` which can be used to define necessary python functionality for keras and pytorch models if necessary.
    * These are not populated initially and would need to be overwritten by a user to access the necessary functions
* Note removal of cumulative gain curve test as this has been removed for use